### PR TITLE
Add stable release of Flac library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "boyhagemann/wave": "dev-master",
-        "bluemoehre/flac-php": "dev-master",
+        "bluemoehre/flac-php": "1.0.2",
         "wapmorgan/mp3info": "~0.0",
         "wapmorgan/binary-stream": "^0.1.5",
         "wapmorgan/file-type-detector": "^1.0.2"


### PR DESCRIPTION
This just brings back a stable version of the library, as they seem to have [moved the Flac class to a namespace](https://github.com/bluemoehre/flac-php/commit/014e64370c3cbc2d75b234a5b552b6711c1e5ab4). This PR could have just added the namespaced version of the file, but I figured it would have been better to just go to an older release :) 